### PR TITLE
Add API to remove items from streams

### DIFF
--- a/api/controllers_suite_test.go
+++ b/api/controllers_suite_test.go
@@ -21,15 +21,23 @@ import (
 var StreamID uuid.UUID
 
 type mockStreamService struct {
-	internal       []model.StreamItem
-	lastItemsOnAdd []model.StreamItem
-	lastLimit      int
-	lastFromSlug   string
+	internal          []model.StreamItem
+	lastItemsOnAdd    []model.StreamItem
+	lastItemsOnRemove []model.StreamItem
+	lastLimit         int
+	lastFromSlug      string
 }
 
 func (s *mockStreamService) Add(items []model.StreamItem) error {
 	s.lastItemsOnAdd = items
 	s.internal = append(s.internal, items...)
+	return nil
+}
+
+func (s *mockStreamService) Remove(items []model.StreamItem) error {
+	s.lastItemsOnRemove = items
+	// I think we should remove items here.
+	//s.internal = append(s.internal, items...)
 	return nil
 }
 

--- a/api/stream_controllers_test.go
+++ b/api/stream_controllers_test.go
@@ -127,6 +127,40 @@ var _ = Describe("StreamController", func() {
 			Expect(response.Code).To(Equal(422))
 		})
 	})
+
+	Context("when removing content via DELETE /streams", func() {
+
+		It("should return a status 200 when passed a correct body", func() {
+			item1ID, _ := uuid.V4()
+			item2ID, _ := uuid.V4()
+			items := []model.StreamItem{{
+				StreamID:  id.String(),
+				Timestamp: time.Now(),
+				Type:      0,
+				ID:        item1ID.String(),
+			}, {
+				StreamID:  id.String(),
+				Timestamp: time.Now(),
+				Type:      1,
+				ID:        item2ID.String(),
+			}}
+			itemsJSON, _ := json.Marshal(items)
+
+			// Create First
+			Request("PUT", "/streams", string(itemsJSON))
+			Expect(response.Code).To(Equal(http.StatusCreated))
+
+			// Now delete
+			Request("DELETE", "/streams", string(itemsJSON))
+			logResponse(response)
+
+			Expect(response.Code).To(Equal(http.StatusOK))
+
+			//verify the items passed into the service are the same
+			checkAll(streamService.lastItemsOnRemove, items)
+		})
+	})
+
 	Context("when retrieving a stream via /stream/:id", func() {
 
 		It("should return a status 201 when accessed with a valid ID", func() {

--- a/service/roshi.go
+++ b/service/roshi.go
@@ -36,6 +36,14 @@ type roshiStreamService struct {
 }
 
 func (s roshiStreamService) Add(items []model.StreamItem) error {
+	return s.RequestWithItems("POST", items)
+}
+
+func (s roshiStreamService) Remove(items []model.StreamItem) error {
+	return s.RequestWithItems("DELETE", items)
+}
+
+func (s roshiStreamService) RequestWithItems(method string, items []model.StreamItem) error {
 	rItems, err := model.ToRoshiStreamItem(items)
 	if err != nil {
 		log.Error(err)
@@ -55,7 +63,7 @@ func (s roshiStreamService) Add(items []model.StreamItem) error {
 		"URL":  uri,
 	}).Debug("Preparing to make request")
 
-	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest(method, uri, bytes.NewBuffer(requestBody))
 	if log.GetLevel() >= log.DebugLevel {
 		debug(httputil.DumpRequestOut(req, true))
 	}

--- a/service/roshi_test.go
+++ b/service/roshi_test.go
@@ -79,5 +79,40 @@ var _ = Describe("Roshi Channel Service", func() {
 				Expect(c1.Timestamp).To(BeTemporally("~", content.Timestamp, time.Millisecond))
 			})
 		})
+
+		Context(".Remove", func() {
+			It("Remove content previously added to the channel", func() {
+				chanID, _ := uuid.V4()
+				contentID, _ := uuid.V4()
+
+				content := model.StreamItem{
+					ID:        contentID.String(),
+					Timestamp: time.Now(),
+					Type:      model.TypePost,
+					StreamID:  chanID.String(),
+				}
+				items := []model.StreamItem{
+					content,
+				}
+				err := s.Add(items)
+				Expect(err).To(BeNil())
+
+				fakeChanID, _ := uuid.V4()
+				q := model.StreamQuery{
+					Streams: []string{fakeChanID.String(), chanID.String()},
+				}
+
+				resp, _ := s.Load(q, 10, "")
+				c := resp.Items
+				Expect(c).NotTo(BeEmpty())
+				Expect(len(c)).To(Equal(1))
+
+				rm_err := s.Remove(items)
+				Expect(rm_err).To(BeNil())
+
+				resp2, _ := s.Load(q, 10, "")
+				Expect(resp2.Items).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/service/stream.go
+++ b/service/stream.go
@@ -8,6 +8,9 @@ type StreamService interface {
 	//Add will add the content items to the embedded stream id
 	Add(items []model.StreamItem) error
 
+	//Remove will remove the content items from the embedded stream id
+	Remove(items []model.StreamItem) error
+
 	//Load will pull a coalesced view of the streams in the query
 	Load(query model.StreamQuery, limit int, fromSlug string) (*model.StreamQueryResponse, error)
 }


### PR DESCRIPTION
This adds the ability to remove delete posts from streams.

Adding a removing via Roshi are almost the exact same except the method used is DELETE instead of post, so some effort was made towards refactoring this functionality.

Be nice, this is my first real Go code. :tada: 